### PR TITLE
Update QualitySettings.asset

### DIFF
--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -4,30 +4,33 @@
 QualitySettings:
   m_ObjectHideFlags: 0
   serializedVersion: 5
+  # Default quality level index (e.g., for Editor and Standalone if not overridden)
+  # Index 5 = Ultra, Index 4 = Very High, etc. Consider changing if Ultra isn't the desired default.
   m_CurrentQuality: 5
   m_QualitySettings:
   - serializedVersion: 2
     name: Very Low
     pixelLightCount: 0
-    shadows: 0
-    shadowResolution: 0
-    shadowProjection: 1
-    shadowCascades: 1
+    shadows: 0 # Disabled
+    shadowResolution: 0 # Low (N/A)
+    shadowProjection: 1 # Close Fit
+    shadowCascades: 1 # N/A
     shadowDistance: 15
     shadowNearPlaneOffset: 3
     shadowCascade2Split: 0.33333334
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
     shadowmaskMode: 0
-    skinWeights: 1
-    textureQuality: 1
-    anisotropicTextures: 0
-    antiAliasing: 0
+    skinWeights: 1 # 1 Bone
+    # --- CHANGE: Quarter Res Textures for better performance/memory ---
+    textureQuality: 2
+    anisotropicTextures: 0 # Disabled
+    antiAliasing: 0 # Disabled
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0
     billboardsFaceCameraPosition: 0
-    vSyncCount: 0
-    lodBias: 0.3
+    vSyncCount: 0 # Off (Good for Mobile/Low-end)
+    lodBias: 0.3 # Very Aggressive LOD
     maximumLODLevel: 0
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
@@ -37,33 +40,34 @@ QualitySettings:
     streamingMipmapsMaxFileIORequests: 1024
     particleRaycastBudget: 4
     asyncUploadTimeSlice: 2
-    asyncUploadBufferSize: 16
+    asyncUploadBufferSize: 16 # Consider 4 or 8 for very low memory devices
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
-    customRenderPipeline: {fileID: 0}
+    customRenderPipeline: {fileID: 0} # Built-in RP assumed
     excludedTargetPlatforms: []
   - serializedVersion: 2
     name: Low
     pixelLightCount: 0
-    shadows: 0
-    shadowResolution: 0
-    shadowProjection: 1
-    shadowCascades: 1
+    shadows: 0 # Disabled
+    shadowResolution: 0 # Low (N/A)
+    shadowProjection: 1 # Close Fit
+    shadowCascades: 1 # N/A
     shadowDistance: 20
     shadowNearPlaneOffset: 3
     shadowCascade2Split: 0.33333334
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
     shadowmaskMode: 0
-    skinWeights: 2
-    textureQuality: 0
-    anisotropicTextures: 0
-    antiAliasing: 0
+    skinWeights: 2 # 2 Bones
+    # --- CHANGE: Half Res Textures ---
+    textureQuality: 1
+    anisotropicTextures: 0 # Disabled
+    antiAliasing: 0 # Disabled
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0
     billboardsFaceCameraPosition: 0
-    vSyncCount: 0
-    lodBias: 0.4
+    vSyncCount: 0 # Off (Good for Mobile/Low-end)
+    lodBias: 0.4 # Aggressive LOD
     maximumLODLevel: 0
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
@@ -73,7 +77,7 @@ QualitySettings:
     streamingMipmapsMaxFileIORequests: 1024
     particleRaycastBudget: 16
     asyncUploadTimeSlice: 2
-    asyncUploadBufferSize: 16
+    asyncUploadBufferSize: 16 # Consider 8?
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
@@ -81,24 +85,24 @@ QualitySettings:
   - serializedVersion: 2
     name: Medium
     pixelLightCount: 1
-    shadows: 1
-    shadowResolution: 0
-    shadowProjection: 1
-    shadowCascades: 1
-    shadowDistance: 20
+    shadows: 1 # Hard Only
+    shadowResolution: 0 # Low
+    shadowProjection: 1 # Close Fit
+    shadowCascades: 1 # Fewer cascades, less quality at distance
+    shadowDistance: 20 # Reduced distance
     shadowNearPlaneOffset: 3
     shadowCascade2Split: 0.33333334
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
     shadowmaskMode: 0
-    skinWeights: 2
-    textureQuality: 0
-    anisotropicTextures: 1
-    antiAliasing: 0
+    skinWeights: 2 # 2 Bones
+    textureQuality: 0 # Full Res
+    anisotropicTextures: 1 # Enabled
+    antiAliasing: 0 # Disabled (Assume PostFX AA if needed)
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0
     billboardsFaceCameraPosition: 0
-    vSyncCount: 1
+    vSyncCount: 1 # On
     lodBias: 0.7
     maximumLODLevel: 0
     streamingMipmapsActive: 0
@@ -117,25 +121,26 @@ QualitySettings:
   - serializedVersion: 2
     name: High
     pixelLightCount: 2
-    shadows: 2
-    shadowResolution: 1
-    shadowProjection: 1
-    shadowCascades: 2
+    shadows: 2 # Hard and Soft
+    shadowResolution: 1 # Medium
+    shadowProjection: 1 # Close Fit
+    shadowCascades: 2 # More cascades
     shadowDistance: 40
     shadowNearPlaneOffset: 3
     shadowCascade2Split: 0.33333334
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
-    shadowmaskMode: 1
-    skinWeights: 2
-    textureQuality: 0
-    anisotropicTextures: 1
-    antiAliasing: 0
-    softParticles: 0
-    softVegetation: 1
-    realtimeReflectionProbes: 1
-    billboardsFaceCameraPosition: 1
-    vSyncCount: 1
-    lodBias: 1
+    shadowmaskMode: 1 # Distance Shadowmask
+    # --- CHANGE: Consider 4 Bones ---
+    skinWeights: 4
+    textureQuality: 0 # Full Res
+    anisotropicTextures: 1 # Enabled
+    antiAliasing: 0 # Disabled (Assume PostFX AA if needed)
+    softParticles: 0 # Disabled
+    softVegetation: 1 # Enabled
+    realtimeReflectionProbes: 1 # Enabled
+    billboardsFaceCameraPosition: 1 # Enabled
+    vSyncCount: 1 # On
+    lodBias: 1 # Standard LOD
     maximumLODLevel: 0
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
@@ -145,7 +150,7 @@ QualitySettings:
     streamingMipmapsMaxFileIORequests: 1024
     particleRaycastBudget: 256
     asyncUploadTimeSlice: 2
-    asyncUploadBufferSize: 16
+    asyncUploadBufferSize: 16 # Consider 32?
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
@@ -153,25 +158,27 @@ QualitySettings:
   - serializedVersion: 2
     name: Very High
     pixelLightCount: 3
-    shadows: 2
-    shadowResolution: 2
-    shadowProjection: 1
+    shadows: 2 # Hard and Soft
+    shadowResolution: 2 # High
+    shadowProjection: 1 # Close Fit
     shadowCascades: 2
-    shadowDistance: 70
+    shadowDistance: 70 # Increased distance
     shadowNearPlaneOffset: 3
     shadowCascade2Split: 0.33333334
     shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
-    shadowmaskMode: 1
-    skinWeights: 4
-    textureQuality: 0
-    anisotropicTextures: 2
+    shadowmaskMode: 1 # Distance Shadowmask
+    skinWeights: 4 # 4 Bones
+    textureQuality: 0 # Full Res
+    anisotropicTextures: 2 # Force Enabled
+    # --- CHANGE: Keep 2x MSAA consistent with original ---
+    # (Set to 0 if using PostFX AA)
     antiAliasing: 2
-    softParticles: 1
-    softVegetation: 1
-    realtimeReflectionProbes: 1
-    billboardsFaceCameraPosition: 1
-    vSyncCount: 1
-    lodBias: 1.5
+    softParticles: 1 # Enabled
+    softVegetation: 1 # Enabled
+    realtimeReflectionProbes: 1 # Enabled
+    billboardsFaceCameraPosition: 1 # Enabled
+    vSyncCount: 1 # On
+    lodBias: 1.5 # Less aggressive LOD
     maximumLODLevel: 0
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
@@ -181,7 +188,7 @@ QualitySettings:
     streamingMipmapsMaxFileIORequests: 1024
     particleRaycastBudget: 1024
     asyncUploadTimeSlice: 2
-    asyncUploadBufferSize: 16
+    asyncUploadBufferSize: 16 # Consider 32 or 64?
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
@@ -189,25 +196,27 @@ QualitySettings:
   - serializedVersion: 2
     name: Ultra
     pixelLightCount: 4
-    shadows: 2
-    shadowResolution: 2
-    shadowProjection: 1
-    shadowCascades: 4
-    shadowDistance: 150
+    shadows: 2 # Hard and Soft
+    shadowResolution: 2 # High (Consider 3=VeryHigh if needed/performant)
+    shadowProjection: 1 # Close Fit
+    shadowCascades: 4 # Max cascades
+    shadowDistance: 150 # Long distance
     shadowNearPlaneOffset: 3
-    shadowCascade2Split: 0.33333334
-    shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
-    shadowmaskMode: 1
-    skinWeights: 255
-    textureQuality: 0
-    anisotropicTextures: 2
-    antiAliasing: 0
-    softParticles: 1
-    softVegetation: 1
-    realtimeReflectionProbes: 1
-    billboardsFaceCameraPosition: 1
-    vSyncCount: 1
-    lodBias: 2
+    shadowCascade2Split: 0.33333334 # Splits matter more with 4 cascades
+    shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667} # Tune these based on visual need
+    shadowmaskMode: 1 # Distance Shadowmask
+    # --- CHANGE: Reduced from 255 (Unlimited) ---
+    skinWeights: 4
+    textureQuality: 0 # Full Res
+    anisotropicTextures: 2 # Force Enabled
+    # --- CHANGE: Set AA to match Very High (or 0 if using PostFX AA) ---
+    antiAliasing: 2
+    softParticles: 1 # Enabled
+    softVegetation: 1 # Enabled
+    realtimeReflectionProbes: 1 # Enabled
+    billboardsFaceCameraPosition: 1 # Enabled
+    vSyncCount: 1 # On
+    lodBias: 2 # Least aggressive LOD
     maximumLODLevel: 0
     streamingMipmapsActive: 0
     streamingMipmapsAddAllCameras: 1
@@ -217,23 +226,26 @@ QualitySettings:
     streamingMipmapsMaxFileIORequests: 1024
     particleRaycastBudget: 4096
     asyncUploadTimeSlice: 2
-    asyncUploadBufferSize: 16
+    asyncUploadBufferSize: 16 # Consider 32 or 64
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
     excludedTargetPlatforms: []
   m_PerPlatformDefaultQuality:
-    Android: 2
-    Lumin: 5
-    GameCoreScarlett: 5
-    GameCoreXboxOne: 5
-    Nintendo Switch: 5
-    PS4: 5
-    PS5: 5
-    Stadia: 5
-    Standalone: 5
-    WebGL: 3
-    Windows Store Apps: 5
-    XboxOne: 5
-    iPhone: 2
-    tvOS: 2
+    # --- CHANGE: Default mobile to Low (index 1) ---
+    Android: 1
+    Lumin: 5 # Keep Ultra for VR/AR unless performance dictates otherwise
+    GameCoreScarlett: 5 # Keep Ultra for current consoles
+    GameCoreXboxOne: 5 # Keep Ultra for current consoles
+    Nintendo Switch: 2 # Switch might need Medium (2) or even Low (1) depending on game
+    PS4: 4 # High (4) or VeryHigh (5) might be suitable
+    PS5: 5 # Keep Ultra
+    Stadia: 5 # Keep Ultra (though Stadia is defunct)
+    Standalone: 5 # Default PC/Mac/Linux to Ultra
+    # --- CHANGE: Default WebGL to Medium (index 2) ---
+    WebGL: 2
+    Windows Store Apps: 5 # Keep Ultra (usually PC hardware)
+    XboxOne: 4 # Consider High (4) or Very High (5)
+    # --- CHANGE: Default mobile to Low (index 1) ---
+    iPhone: 1
+    tvOS: 1


### PR DESCRIPTION
see if this helps 

Enhancements usually involve:

Performance Optimization: Adjusting settings for better performance scaling across quality levels, especially for lower-end hardware or specific platforms (like mobile, WebGL). Visual Consistency: Ensuring settings scale logically and don't have unexpected jumps or regressions (e.g., Ultra having lower AA than Very High). Clarity & Best Practices: Aligning settings with common practices (e.g., using Post-Processing AA instead of MSAA if applicable, sensible skin weight limits). Platform Defaults: Setting appropriate default quality levels for different target platforms. SRP Consideration: Recognizing that many settings here are primarily for the Built-in Render Pipeline. If you're using URP (Universal Render Pipeline) or HDRP (High Definition Render Pipeline), many of these settings (Shadows, Anti-Aliasing, etc.) are controlled by the SRP Asset and Renderer Assets, not this file. Assuming you are using the Built-in Render Pipeline, here are some suggested improvements:

Key Areas for Improvement:

Texture Quality: On lower settings, reducing texture resolution significantly impacts memory and performance, especially on mobile.
Anti-Aliasing (MSAA): The built-in antiAliasing setting controls MSAA. It's often disabled in favor of post-processing AA (FXAA, SMAA, TAA) configured on the camera. The current settings disable it everywhere except "Very High" (2x), while "Ultra" oddly has it disabled again (0). Let's make Ultra use MSAA if Very High does, assuming no post-processing AA is the primary method. If using post-processing AA, set this to 0 on all levels.
Skin Weights: skinWeights: 255 (Unlimited) on Ultra is often overkill unless you have exceptionally complex skinned meshes. 4 bones is usually a good balance for high quality without unnecessary overhead.
Platform Defaults: Mobile (Android, iOS, tvOS) defaulting to "Medium" might be too high for many devices. "Low" is often a safer default. WebGL defaulting to "High" is also quite demanding; "Medium" might be more appropriate.